### PR TITLE
Fix dependency on Magento_Integration version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
 	],
 	"require" : {
 		"php" : "7.0.2|7.0.4|~7.0.6|~7.1.0",
-		"magento/module-integration" : "2.0.0"
+		"magento/module-integration" : "~100.0"
 	},
 	"autoload" : {
 		"files" : [


### PR DESCRIPTION
Magento_Integration API is used to create integration account for Shopial. In a case of backward incompatible changes in Magento_Integration module (major version bump from 100 to 101) this extension should be reviewed and tested.