### PR TITLE
Update semicolons format - this causes errors

### DIFF
--- a/etc/integration.xml
+++ b/etc/integration.xml
@@ -11,7 +11,7 @@
         <identity_link_url>https://fbapp.ezsocialshop.com/facebook/index.php/magento2/show_magento_success_popup</identity_link_url>
         <resources>
             <resource name="Magento_Catalog::products" />
-            <resource name=“Magento_Backend::store” />
+            <resource name="Magento_Backend::store" />
         </resources>
     </integration>
 </config>


### PR DESCRIPTION
“Magento_Backend::store” should be changed for "Magento_Backend::store"

Otherwise on setup:upgrade the error appears:

Invalid XML in file /app/vendor/shopial/facebook-module/etc/integration.xml:
AttValue: " or ' expected
Line: 14
attributes construct error
Line: 14
Couldn't find end of Start Tag resource line 14
Line: 14